### PR TITLE
allow null return type

### DIFF
--- a/src/models/Vehicle.php
+++ b/src/models/Vehicle.php
@@ -320,7 +320,7 @@ class Vehicle
      * @return bool|int|string
      * @throws Exception
      */
-    public function __get(string $property): bool|int|string
+    public function __get(string $property): null|bool|int|string
     {
         return match ($property)
         {


### PR DESCRIPTION
The methods __get calls to return allow null, so it needs to too.